### PR TITLE
Get test data as dictionary

### DIFF
--- a/NUnitTfsTestCase/NUnitTfsTestCase/TestCaseData/TestCaseDataTfs.cs
+++ b/NUnitTfsTestCase/NUnitTfsTestCase/TestCaseData/TestCaseDataTfs.cs
@@ -16,7 +16,7 @@ namespace NUnitTfsTestCase.TestCaseData
         /// <returns>IEnumerable with array of values casted to dynamic.</returns>
         public static IEnumerable<dynamic> GetTestDataInternal(int testCaseId)
         {
-            yield return GetTestDataAsArray(testCaseId) as dynamic;
+            return GetTestDataAsArray(testCaseId);
         }
 
         /// <summary>

--- a/NUnitTfsTestCase/NUnitTfsTestCase/TestCaseData/TestCaseDataTfs.cs
+++ b/NUnitTfsTestCase/NUnitTfsTestCase/TestCaseData/TestCaseDataTfs.cs
@@ -1,33 +1,80 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NUnitTfsTestCase.TestCaseData
 {
     public class TestCaseDataTfs
     {
-        private static DataTable GetTestCaseParams(int TestCaseId)
+        /// <summary>
+        /// Takes all parameters from specified test case.
+        /// Same as <see cref="GetTestDataAsArray"/>, but with casting to dynamic.
+        /// Saved to avoid errors while users updating from one version to another.
+        /// </summary>
+        /// <param name="testCaseId">Number of test case where parameters taken.</param>
+        /// <returns>IEnumerable with array of values casted to dynamic.</returns>
+        public static IEnumerable<dynamic> GetTestDataInternal(int testCaseId)
         {
-            int testCaseId = TestCaseId;
+            yield return GetTestDataAsArray(testCaseId) as dynamic;
+        }
+
+        /// <summary>
+        /// Takes all parameters from specified test case.
+        /// Params stored as { ParamValue1, ParamValue2, ParamValue3 }.
+        /// Same as <see cref="GetTestDataInternal"/>, but without casting to dynamic. 
+        /// </summary>
+        /// <param name="testCaseId">Number of test case where parameters taken.</param>
+        /// <returns>IEnumerable with array of values. Each object [] represents single line with parameters.</returns>
+        public static IEnumerable<object []> GetTestDataAsArray(int testCaseId)
+        {
+            return GetTestData(testCaseId, CollectTestDataAsArray);
+        }
+
+        /// <summary>
+        /// Takes all parameters from specified test case.
+        /// Params stored as { { ParamName1, ParamValue1 }, { ParamName2, ParamValue2 }, { ParamName3, ParamValue3 } }.
+        /// </summary>
+        /// <param name="testCaseId">Number of test case where parameters taken.</param>
+        /// <returns>IEnumerable with dictionary of names and values. Each Dictionary represents single line with pairs of name and value of parameter.</returns>
+        public static IEnumerable<Dictionary<string, object>> GetTestDataAsDictionary(int testCaseId)
+        {
+            return GetTestData(testCaseId, CollectTestDataAsDictionary);
+        }
+
+        private static DataTable GetTestCaseParams(int testCaseId)
+        {
             var testCase = TfsService.ProjectConnection.TestManagementProject.TestCases.Find(testCaseId);
             return testCase.DefaultTableReadOnly;
         }
 
-        public static IEnumerable<dynamic> GetTestDataInternal(int TestCaseID)
+        private static IEnumerable<T> GetTestData<T>(int testCaseId, Func<DataRow, DataColumnCollection, T> storageFunc) where T: IEnumerable
         {
-            var tb = GetTestCaseParams(TestCaseID);
-            foreach (DataRow dr in tb.Rows)
+            var tcParams = GetTestCaseParams(testCaseId);
+            foreach (DataRow dr in tcParams.Rows)
             {
-                var ob = new List<object>();
-                for (var i = 0; i < tb.Columns.Count; i++)
-                {
-                    ob.Add(dr[i]);
-                }
-                yield return ob.ToArray();
+                yield return storageFunc(dr, tcParams.Columns);
             }
+        }
+
+        private static Dictionary<string, object> CollectTestDataAsDictionary(DataRow dr, DataColumnCollection dcc)
+        {
+            var dict = new Dictionary<string, object>();
+            for (int i = 0; i < dcc.Count; i++)
+            {
+                dict.Add(dcc[i].ColumnName, dr[i]);
+            }
+            return dict;
+        }
+
+        private static object [] CollectTestDataAsArray(DataRow dr, DataColumnCollection dcc)
+        {
+            var array = new object [dcc.Count];
+            for (int i = 0; i < dcc.Count; i++)
+            {
+                array[i] = dr[i];
+            }
+            return array;
         }
     }
 }


### PR DESCRIPTION
I found this library pretty useful and interesting, thanks for that!
But for my project I want to migrate tests from MSTest to nUnit and the problem was to add TFS support with minor changes of tests code.
That is why I decided to add possibility to receive test data as  dictionary (ms test has attribute 
```
[DataSource(DATA_SOURCE, TFS_TRACKER_URL, TEST_CASE_ID", DataAccessMethod.Sequential)]
```
and code part 
```
var username = TestContext.DataRow["user"].ToString();
```
), so dictionary allows to follow this code style even if it must be added as test param.